### PR TITLE
Add missing .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and fill in only the values you need.
+
+# Private key used for testnet deployments and task execution.
+# Use a funded testnet-only key, not a mainnet key.
+PRIVATE_KEY=
+
+# Base Sepolia RPC endpoint. The public endpoint below is used as a fallback
+# when this value is not set.
+BASE_SEPOLIA_RPC_URL=
+
+# Optional explorer API keys for contract verification.
+ETHERSCAN_API_KEY=
+ARBISCAN_API_KEY=
+BASESCAN_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .env
+!.env.example
 
 # Hardhat files
 /cache


### PR DESCRIPTION
Fixes #12.

The README already tells users to copy `.env.example` before running testnet tasks, but the file was missing and `.gitignore` only ignored `.env`.

This adds a small template for the variables read by `hardhat.config.ts` and keeps real `.env` files ignored.

Checked:
- `git diff --check`
- `mise exec node@20 -- pnpm test` (12 passing)

Note: I used Node 20 for the test run because Hardhat warns on Node 25 locally.
